### PR TITLE
Diffobj performance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Collate: 
     'FileComparator.R'
     'BinaryFileComparator.R'

--- a/R/TxtFileComparator.R
+++ b/R/TxtFileComparator.R
@@ -135,7 +135,8 @@ TxtFileComparator <- R6::R6Class(
         file2_contents_whole,
         context = context,
         style = style,
-        mode = "sidebyside"
+        mode = "sidebyside",
+        word.diff = FALSE
       )
       self$vrf_close_debug()
 
@@ -214,8 +215,9 @@ my_finalizer <- function(x, x.chr, omit) {
   width <- nchar(length(split))
   index <- 0
 
-  # add row numbers to compare results manually for diffChr. diffobj-header values
-  # need to be processed to identify the actual line numbers in summary results.
+  # add row numbers to compare results manually for diffChr. diffobj-header
+  # values need to be processed to identify the actual line numbers in summary
+  # results.
   for (i in seq_along(split)) {
     row <- split[[i]]
 
@@ -233,19 +235,34 @@ my_finalizer <- function(x, x.chr, omit) {
 
       row <- gsub(
         "<div class='diffobj-text'><div class='diffobj-match'>",
-        paste0("<div class='diffobj-text'><div class='diffobj-match'><span class='diffobj-trim'>", row_str, "</span>"),
+        paste0(
+          "<div class='diffobj-text'><div class='diffobj-match'>",
+          "<span class='diffobj-trim'>",
+          row_str,
+          "</span>"
+        ),
         row
       )
 
       row <- gsub(
         "<div class='diffobj-text'><div class='delete'>",
-        paste0("<div class='diffobj-text'><div class='delete'><span class='diffobj-trim'>", row_str, "</span>"),
+        paste0(
+          "<div class='diffobj-text'><div class='delete'>",
+          "<span class='diffobj-trim'>",
+          row_str,
+          "</span>"
+        ),
         row
       )
 
       row <- gsub(
         "<div class='diffobj-text'><div class='insert'>",
-        paste0("<div class='diffobj-text'><div class='insert'><span class='diffobj-trim'>", row_str, "</span>"),
+        paste0(
+          "<div class='diffobj-text'><div class='insert'>",
+          "<span class='diffobj-trim'>",
+          row_str,
+          "</span>"
+        ),
         row
       )
 

--- a/inst/shiny_examples/app/app.R
+++ b/inst/shiny_examples/app/app.R
@@ -27,6 +27,7 @@ dt_comparators_list <- list()
 row_index <- NULL
 
 current_mode <- shiny::reactiveVal(NULL)
+current_omit <- NULL
 
 # ==============================================================================
 # Custom input functions
@@ -337,7 +338,7 @@ update_details_comparison <- function(
     {
       comparator <- get_comparator(row_index, file1, file2)
       details <- comparator$vrf_details(
-        omit   = input$omit_rows,
+        omit   = current_omit,
         config = options
       )
 
@@ -717,7 +718,7 @@ server <- function(input, output, session) {
 
     dt_file_list <- tibble::tibble(list_of_files()) %>%
       dplyr::mutate(
-        omitted = input$omit_rows,
+        omitted = current_omit,
         comparison = NA_character_,
         comments = "no",
         comments_details = "",
@@ -827,6 +828,8 @@ server <- function(input, output, session) {
 
 list_files <- function(input, summary_text) {
   if (input$compare_tabs == "tabs_folder") {
+    current_omit <<- input$omit_rows
+
     if (file.exists(input$folder1) && file.exists(input$folder2)) {
       set_visibility("comparison_comments_container", FALSE)
       shinyjs::runjs("$('#download_csv').css('display', 'inline-block');")
@@ -845,6 +848,8 @@ list_files <- function(input, summary_text) {
       NULL
     }
   } else {
+    current_omit <<- input$omit_file_rows
+
     if (file.exists(input$file1) && file.exists(input$file2)) {
       set_visibility("comparison_comments_container", FALSE)
       shinyjs::runjs("$('#download_csv').css('display', 'inline-block');")


### PR DESCRIPTION
* use diffObj::diffChr instead of diffObj::diffPrint for improved performance. Implemented some additional processing for result rendering to retain similar result display (line numbers etc).